### PR TITLE
Xbox controller support

### DIFF
--- a/DLL/DLL.vcxproj
+++ b/DLL/DLL.vcxproj
@@ -92,7 +92,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\kiero;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\imgui\backends;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\detours\include;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\imgui</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)kiero;$(ProjectDir)imgui\backends;$(ProjectDir)detours\include;$(ProjectDir)imgui;$(ProjectDir)ois\includes;$(ProjectDir)stb;$(ProjectDir)tsl;$(ProjectDir)inifile-cpp\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
@@ -100,7 +100,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalLibraryDirectories>D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\detours\lib.X64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(ProjectDir)detours\lib.X64;$(ProjectDir)ois\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -112,7 +112,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>shared.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\stb;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\ois\includes;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\tsl;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\inifile-cpp\include;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\zydis\include;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\sdl\include;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\sdl3\include\SDL3;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\kiero\minhook\include;C:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Include;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\imgui\backends;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\kiero;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\detours\include;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\imgui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)kiero;$(ProjectDir)imgui\backends;$(ProjectDir)detours\include;$(ProjectDir)imgui;$(ProjectDir)ois\includes;$(ProjectDir)stb;$(ProjectDir)tsl;$(ProjectDir)inifile-cpp\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -123,8 +123,8 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>d3d11.lib;d3dcompiler.lib;dxgi.lib;dxguid.lib;detours.lib;user32.lib;OIS.lib;dinput8.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\ois\lib;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\zydis\lib;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\sdl\lib\x64;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\sdl3\lib\x64;C:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Lib\x64;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\kiero\minhook\lib;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\detours\lib.X64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>d3d11.lib;d3dcompiler.lib;dxgi.lib;dxguid.lib;detours.lib;user32.lib;OIS.lib;dinput8.lib;xinput.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(ProjectDir)detours\lib.X64;$(ProjectDir)ois\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -135,7 +135,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\kiero;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\imgui\backends;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\detours\include;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\imgui</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)kiero;$(ProjectDir)imgui\backends;$(ProjectDir)detours\include;$(ProjectDir)imgui;$(ProjectDir)ois\includes;$(ProjectDir)stb;$(ProjectDir)tsl;$(ProjectDir)inifile-cpp\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
@@ -143,7 +143,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalLibraryDirectories>D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\detours\lib.X64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(ProjectDir)detours\lib.X64;$(ProjectDir)ois\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -157,7 +157,7 @@
       <PrecompiledHeaderFile>shared.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
-      <AdditionalIncludeDirectories>D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\stb;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\ois\includes;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\tsl;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\inifile-cpp\include;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\zydis\include;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\sdl\include;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\sdl3\include\SDL3;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\kiero\minhook\include;C:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Include;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\imgui\backends;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\kiero;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\detours\include;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\imgui;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)kiero;$(ProjectDir)imgui\backends;$(ProjectDir)detours\include;$(ProjectDir)imgui;$(ProjectDir)ois\includes;$(ProjectDir)stb;$(ProjectDir)tsl;$(ProjectDir)inifile-cpp\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PreprocessorDefinitions>SDL_STATIC;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Optimization>MaxSpeed</Optimization>
@@ -166,8 +166,8 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>d3d11.lib;d3dcompiler.lib;dxgi.lib;dxguid.lib;detours.lib;user32.lib;OIS.lib;dinput8.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\ois\lib;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\zydis\lib;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\sdl\lib\x64;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\sdl3\lib\x64;C:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Lib\x64;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\kiero\minhook\lib;D:\Users\draft\source\repos\SnowRunner Manual Transmission\DLL\detours\lib.X64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>d3d11.lib;d3dcompiler.lib;dxgi.lib;dxguid.lib;detours.lib;user32.lib;OIS.lib;dinput8.lib;xinput.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(ProjectDir)detours\lib.X64;$(ProjectDir)ois\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/DLL/config.cpp
+++ b/DLL/config.cpp
@@ -4,6 +4,96 @@
 const std::string configFilename = "SMT.ini";
 ini::IniFile iniConfig;
 
+namespace {
+	std::atomic<bool> disableGameShifting = false;
+	std::atomic<bool> skipNeutral = false;
+	std::atomic<bool> requireClutch = false;
+	std::atomic<bool> immersiveMode = false;
+	std::atomic<bool> requireGearHeld = false;
+	std::atomic<bool> debugLogging = false;
+
+	const char* GetRuntimeOptionName(RuntimeOption option) {
+		switch (option) {
+		case RuntimeOption::DisableGameShifting:
+			return "DISABLE GAME SHIFTING";
+		case RuntimeOption::SkipNeutral:
+			return "SKIP NEUTRAL";
+		case RuntimeOption::RequireClutch:
+			return "REQUIRE CLUTCH";
+		case RuntimeOption::ImmersiveMode:
+			return "IMMERSIVE MODE";
+		case RuntimeOption::RequireGearHeld:
+			return "REQUIRE GEAR HELD";
+		case RuntimeOption::DebugLogging:
+			return "DEBUG LOGGING";
+		}
+		return "";
+	}
+
+	std::atomic<bool>& GetRuntimeOptionStorage(RuntimeOption option) {
+		switch (option) {
+		case RuntimeOption::DisableGameShifting:
+			return disableGameShifting;
+		case RuntimeOption::SkipNeutral:
+			return skipNeutral;
+		case RuntimeOption::RequireClutch:
+			return requireClutch;
+		case RuntimeOption::ImmersiveMode:
+			return immersiveMode;
+		case RuntimeOption::RequireGearHeld:
+			return requireGearHeld;
+		case RuntimeOption::DebugLogging:
+			return debugLogging;
+		}
+		return disableGameShifting;
+	}
+
+	bool TryParseRuntimeOption(const std::string& optionName, RuntimeOption& option) {
+		if (optionName == "DISABLE GAME SHIFTING") {
+			option = RuntimeOption::DisableGameShifting;
+			return true;
+		}
+		if (optionName == "SKIP NEUTRAL") {
+			option = RuntimeOption::SkipNeutral;
+			return true;
+		}
+		if (optionName == "REQUIRE CLUTCH") {
+			option = RuntimeOption::RequireClutch;
+			return true;
+		}
+		if (optionName == "IMMERSIVE MODE") {
+			option = RuntimeOption::ImmersiveMode;
+			return true;
+		}
+		if (optionName == "REQUIRE GEAR HELD") {
+			option = RuntimeOption::RequireGearHeld;
+			return true;
+		}
+		if (optionName == "DEBUG LOGGING") {
+			option = RuntimeOption::DebugLogging;
+			return true;
+		}
+		return false;
+	}
+
+	bool IsTransientBindingValue(const std::string& value) {
+		return value == "LISTENING" || value == "FOUND";
+	}
+
+	void WriteRuntimeOptionsToIni() {
+		for (RuntimeOption option : {
+			RuntimeOption::DisableGameShifting,
+			RuntimeOption::SkipNeutral,
+			RuntimeOption::RequireClutch,
+			RuntimeOption::ImmersiveMode,
+			RuntimeOption::RequireGearHeld,
+			RuntimeOption::DebugLogging
+			}) {
+			iniConfig["OPTIONS"][GetRuntimeOptionName(option)] = GetRuntimeOption(option);
+		}
+	}
+}
+
 ini::IniFile WriteDefaultIniConfig() {
 	ini::IniFile defaultIniConfig;
 	defaultIniConfig["KEYBOARD"]["GEAR 1"] = "NONE";
@@ -61,6 +151,7 @@ ini::IniFile WriteDefaultIniConfig() {
 	defaultIniConfig["OPTIONS"]["REQUIRE CLUTCH"] = false;
 	defaultIniConfig["OPTIONS"]["IMMERSIVE MODE"] = false;
 	defaultIniConfig["OPTIONS"]["REQUIRE GEAR HELD"] = false;
+	defaultIniConfig["OPTIONS"]["DEBUG LOGGING"] = false;
 
 	return defaultIniConfig;
 }
@@ -81,8 +172,66 @@ void LoadIniConfig() {
 		iniConfig.save(configFilename);
 		LogMessage("Ini config not found. Using default.");
 	}
+	SyncRuntimeOptionsFromIni();
 }
 
 void SaveIniConfig() {
+	WriteRuntimeOptionsToIni();
 	iniConfig.save(configFilename);
+}
+
+bool GetRuntimeOption(RuntimeOption option) {
+	return GetRuntimeOptionStorage(option).load(std::memory_order_relaxed);
+}
+
+bool IsDebugLoggingEnabled() {
+	return GetRuntimeOption(RuntimeOption::DebugLogging);
+}
+
+bool GetRuntimeOptionValue(const std::string& optionName) {
+	RuntimeOption option;
+	if (TryParseRuntimeOption(optionName, option)) {
+		return GetRuntimeOption(option);
+	}
+	return iniConfig["OPTIONS"][optionName].as<bool>();
+}
+
+void SetBindingValue(const std::string& categoryName, const std::string& bindingName, const std::string& value) {
+	const std::string currentValue = iniConfig[categoryName][bindingName].as<std::string>();
+	if (currentValue == value) {
+		return;
+	}
+
+	iniConfig[categoryName][bindingName] = value;
+	if (!IsTransientBindingValue(value)) {
+		SaveIniConfig();
+	}
+}
+
+void SetRuntimeOptionValue(const std::string& optionName, bool value) {
+	RuntimeOption option;
+	if (TryParseRuntimeOption(optionName, option)) {
+		GetRuntimeOptionStorage(option).store(value, std::memory_order_relaxed);
+		if (option == RuntimeOption::DebugLogging) {
+			LogMessage("Debug logging", value ? "enabled" : "disabled");
+		}
+		return;
+	}
+	iniConfig["OPTIONS"][optionName] = value;
+}
+
+void SyncRuntimeOptionsFromIni() {
+	for (RuntimeOption option : {
+		RuntimeOption::DisableGameShifting,
+			RuntimeOption::SkipNeutral,
+			RuntimeOption::RequireClutch,
+			RuntimeOption::ImmersiveMode,
+			RuntimeOption::RequireGearHeld,
+			RuntimeOption::DebugLogging
+			}) {
+		GetRuntimeOptionStorage(option).store(
+			iniConfig["OPTIONS"][GetRuntimeOptionName(option)].as<bool>(),
+			std::memory_order_relaxed
+		);
+	}
 }

--- a/DLL/config.h
+++ b/DLL/config.h
@@ -1,6 +1,21 @@
 #pragma once
 #include "shared.h"
 
+enum class RuntimeOption {
+	DisableGameShifting,
+	SkipNeutral,
+	RequireClutch,
+	ImmersiveMode,
+	RequireGearHeld,
+	DebugLogging
+};
+
 extern ini::IniFile iniConfig;
+extern bool GetRuntimeOption(RuntimeOption option);
+extern bool IsDebugLoggingEnabled();
+extern bool GetRuntimeOptionValue(const std::string& optionName);
+extern void SetBindingValue(const std::string& categoryName, const std::string& bindingName, const std::string& value);
+extern void SetRuntimeOptionValue(const std::string& optionName, bool value);
+extern void SyncRuntimeOptionsFromIni();
 extern void LoadIniConfig();
 extern void SaveIniConfig();

--- a/DLL/game_data.cpp
+++ b/DLL/game_data.cpp
@@ -3,10 +3,347 @@
 #include "memory.h"
 #include "config.h"
 #include "input.h"
+#include <algorithm>
+#include <cmath>
+#include <mutex>
 
-std::atomic<float> currentCoef = 1.05f;
+namespace {
+	enum class TransmissionMode {
+		Default,
+		Low,
+		LowPlus,
+		LowMinus
+	};
 
-std::unordered_map <Vehicle*, std::atomic<bool>> IsInAuto{};
+	struct ActiveTransmissionState {
+		const Vehicle* VehicleRef = nullptr;
+		std::int32_t RequestedGear = 1;
+		TransmissionMode Mode = TransmissionMode::Default;
+		float PowerCoef = PowerCoefDefaultGear;
+		bool Hydrated = false;
+	};
+
+	std::recursive_mutex transmissionMutex;
+	ActiveTransmissionState activeTransmissionState;
+	thread_local int32_t modShiftDepth = 0;
+	constexpr float PowerCoefTolerance = 0.05f;
+	bool EnsureActiveTransmissionStateForVehicleUnlocked(Vehicle* veh);
+
+	class ScopedModShift {
+	public:
+		ScopedModShift() {
+			++modShiftDepth;
+		}
+
+		~ScopedModShift() {
+			--modShiftDepth;
+		}
+	};
+
+	bool IsModShiftActive() {
+		return modShiftDepth > 0;
+	}
+
+	bool ApproximatelyEqual(float lhs, float rhs) {
+		return std::fabs(lhs - rhs) <= PowerCoefTolerance;
+	}
+
+	bool UsesDefaultPower(const ActiveTransmissionState& state) {
+		return state.Mode == TransmissionMode::Default;
+	}
+
+	const char* TransmissionModeName(TransmissionMode mode) {
+		switch (mode) {
+		case TransmissionMode::Default:
+			return "DEFAULT";
+		case TransmissionMode::Low:
+			return "LOW";
+		case TransmissionMode::LowPlus:
+			return "LOW_PLUS";
+		case TransmissionMode::LowMinus:
+			return "LOW_MINUS";
+		}
+		return "UNKNOWN";
+	}
+
+	float EffectivePowerCoef(const ActiveTransmissionState& state) {
+		return UsesDefaultPower(state) ? PowerCoefDefaultGear : state.PowerCoef;
+	}
+
+	void ResetActiveTransmissionState(const Vehicle* veh) {
+		activeTransmissionState.VehicleRef = veh;
+		activeTransmissionState.RequestedGear = 1;
+		activeTransmissionState.Mode = TransmissionMode::Default;
+		activeTransmissionState.PowerCoef = PowerCoefDefaultGear;
+		activeTransmissionState.Hydrated = veh != nullptr;
+	}
+
+	std::int32_t HighGearValue(const Vehicle* veh) {
+		return veh->GetMaxGear() + 1;
+	}
+
+	std::int32_t NormalizeRequestedGear(const Vehicle* veh, std::int32_t requestedGear) {
+		if (requestedGear == 99) {
+			return HighGearValue(veh);
+		}
+
+		return std::clamp(requestedGear, -1, veh->GetMaxGear());
+	}
+
+	std::int32_t RequestedGearFromGameGear(const Vehicle* veh, std::int32_t gear) {
+		return gear > veh->GetMaxGear() ? 99 : std::clamp(gear, -1, veh->GetMaxGear());
+	}
+
+	std::int32_t CurrentRequestedTargetGearUnlocked(Vehicle* veh) {
+		if (!EnsureActiveTransmissionStateForVehicleUnlocked(veh)) {
+			return 0;
+		}
+
+		return NormalizeRequestedGear(veh, activeTransmissionState.RequestedGear);
+	}
+
+	void MirrorManualGearState(Vehicle* veh, std::int32_t targetGear) {
+		if (veh == nullptr || veh->TruckAction == nullptr) {
+			return;
+		}
+
+		veh->TruckAction->IsInAutoMode = false;
+		veh->TruckAction->Gear_2 = targetGear;
+		veh->TruckAction->NextGear = targetGear;
+	}
+
+	bool ShouldAllowNativeAutoShifting();
+	bool ShouldForceManualDriveState();
+
+	bool IsInNativeAutoState(const Vehicle* veh) {
+		return ShouldAllowNativeAutoShifting()
+			&& veh != nullptr
+			&& veh->TruckAction != nullptr
+			&& veh->TruckAction->IsInAutoMode;
+	}
+
+	bool ShouldPreserveManualControllerState(const Vehicle* veh) {
+		return ShouldForceManualDriveState()
+			|| (veh != nullptr
+				&& veh->TruckAction != nullptr
+				&& !veh->TruckAction->IsInAutoMode);
+	}
+
+	void SyncActiveTransmissionStateFromVehicleUnlocked(Vehicle* veh) {
+		const ActiveTransmissionState previousState = activeTransmissionState;
+		ResetActiveTransmissionState(veh);
+		if (veh == nullptr || veh->TruckAction == nullptr) {
+			return;
+		}
+
+		const std::int32_t maxGear = veh->GetMaxGear();
+		const std::int32_t actualGear = veh->TruckAction->Gear_1;
+		const float powerCoef = veh->TruckAction->PowerCoef;
+
+		if (ApproximatelyEqual(powerCoef, PowerCoefLowGear)) {
+			activeTransmissionState.Mode = TransmissionMode::Low;
+			activeTransmissionState.PowerCoef = PowerCoefLowGear;
+			activeTransmissionState.RequestedGear = 1;
+			return;
+		}
+		if (previousState.VehicleRef == veh
+			&& previousState.Hydrated
+			&& previousState.Mode == TransmissionMode::LowPlus
+			&& actualGear == 1
+			&& ApproximatelyEqual(powerCoef, PowerCoefLowPlusGear)
+			&& ShouldPreserveManualControllerState(veh)) {
+			activeTransmissionState.Mode = TransmissionMode::LowPlus;
+			activeTransmissionState.PowerCoef = PowerCoefLowPlusGear;
+			activeTransmissionState.RequestedGear = 1;
+			return;
+		}
+		if (ApproximatelyEqual(powerCoef, PowerCoefLowMinusGear)) {
+			activeTransmissionState.Mode = TransmissionMode::LowMinus;
+			activeTransmissionState.PowerCoef = PowerCoefLowMinusGear;
+			activeTransmissionState.RequestedGear = 1;
+			return;
+		}
+
+		activeTransmissionState.Mode = TransmissionMode::Default;
+		activeTransmissionState.PowerCoef = PowerCoefDefaultGear;
+		activeTransmissionState.RequestedGear = RequestedGearFromGameGear(veh, actualGear);
+		if (ShouldPreserveManualControllerState(veh)) {
+			const std::int32_t pendingGear = RequestedGearFromGameGear(veh, veh->TruckAction->NextGear);
+			if (pendingGear != activeTransmissionState.RequestedGear) {
+				activeTransmissionState.RequestedGear = pendingGear;
+			}
+		}
+	}
+
+	bool EnsureActiveTransmissionStateForVehicleUnlocked(Vehicle* veh) {
+		if (veh == nullptr) {
+			return false;
+		}
+
+		if (activeTransmissionState.VehicleRef != veh || !activeTransmissionState.Hydrated) {
+			SyncActiveTransmissionStateFromVehicleUnlocked(veh);
+		}
+
+		return true;
+	}
+
+	std::int32_t CurrentLogicalGearUnlocked(Vehicle* veh) {
+		if (!EnsureActiveTransmissionStateForVehicleUnlocked(veh)) {
+			return 0;
+		}
+
+		if (activeTransmissionState.RequestedGear == 99) {
+			return HighGearValue(veh);
+		}
+
+		return NormalizeRequestedGear(veh, activeTransmissionState.RequestedGear);
+	}
+
+	void SetDefaultRequestedGearUnlocked(Vehicle* veh, std::int32_t requestedGear) {
+		EnsureActiveTransmissionStateForVehicleUnlocked(veh);
+		activeTransmissionState.Mode = TransmissionMode::Default;
+		activeTransmissionState.PowerCoef = PowerCoefDefaultGear;
+		activeTransmissionState.RequestedGear = requestedGear;
+	}
+
+	void SetLowRequestedGearUnlocked(Vehicle* veh, TransmissionMode mode, float powerCoef) {
+		EnsureActiveTransmissionStateForVehicleUnlocked(veh);
+		activeTransmissionState.Mode = mode;
+		activeTransmissionState.PowerCoef = powerCoef;
+		activeTransmissionState.RequestedGear = 1;
+	}
+
+	bool ApplyRequestedGearNativeUnlocked(Vehicle* veh, std::int32_t targetGear) {
+		if (veh == nullptr) {
+			return false;
+		}
+
+		const std::int32_t maxGear = veh->GetMaxGear();
+		if (targetGear > maxGear) {
+			return ShiftToHighO(veh);
+		}
+		if (targetGear < 0) {
+			return ShiftToReverseO(veh);
+		}
+		if (targetGear == 0) {
+			return ShiftToNeutralO(veh);
+		}
+		return DisableAutoAndShiftO(veh, targetGear);
+	}
+
+	bool ApplyActiveTransmissionStateUnlocked(Vehicle* veh) {
+		if (!EnsureActiveTransmissionStateForVehicleUnlocked(veh)) {
+			return false;
+		}
+
+		const std::int32_t targetGear = NormalizeRequestedGear(veh, activeTransmissionState.RequestedGear);
+		const float powerCoef = EffectivePowerCoef(activeTransmissionState);
+		const std::int32_t actualGearBefore = veh->TruckAction != nullptr ? veh->TruckAction->Gear_1 : 0;
+
+		DebugLogMessage(
+			"ApplyTransmission",
+			"veh", static_cast<const void*>(veh),
+			"requested", activeTransmissionState.RequestedGear,
+			"target", targetGear,
+			"mode", TransmissionModeName(activeTransmissionState.Mode),
+			"coef", powerCoef,
+			"actual_before", actualGearBefore
+		);
+
+		ScopedModShift modShiftScope;
+		const bool shifted = ApplyRequestedGearNativeUnlocked(veh, targetGear);
+		SetPowerCoefO(veh, powerCoef);
+		MirrorManualGearState(veh, targetGear);
+
+		SyncActiveTransmissionStateFromVehicleUnlocked(veh);
+		DebugLogMessage(
+			"ApplyTransmissionResult",
+			"veh", static_cast<const void*>(veh),
+			"shifted", shifted,
+			"actual_after", veh->TruckAction != nullptr ? veh->TruckAction->Gear_1 : 0,
+			"next_after", veh->TruckAction != nullptr ? veh->TruckAction->NextGear : 0,
+			"gear2_after", veh->TruckAction != nullptr ? veh->TruckAction->Gear_2 : 0,
+			"mode_after", TransmissionModeName(activeTransmissionState.Mode),
+			"requested_after", activeTransmissionState.RequestedGear
+		);
+		return shifted || (veh->TruckAction != nullptr && veh->TruckAction->Gear_1 == targetGear);
+	}
+
+	void EnforceActiveTransmissionStateUnlocked(Vehicle* veh) {
+		if (!EnsureActiveTransmissionStateForVehicleUnlocked(veh)) {
+			return;
+		}
+
+		SetPowerCoefO(veh, EffectivePowerCoef(activeTransmissionState));
+		MirrorManualGearState(veh, CurrentRequestedTargetGearUnlocked(veh));
+	}
+
+	bool ShouldBlockGameShifting() {
+		return GetRuntimeOption(RuntimeOption::DisableGameShifting) && !IsModShiftActive();
+	}
+
+	bool ShouldAllowNativeAutoShifting() {
+		return !GetRuntimeOption(RuntimeOption::DisableGameShifting)
+			&& !GetRuntimeOption(RuntimeOption::ImmersiveMode)
+			&& !GetRuntimeOption(RuntimeOption::RequireClutch);
+	}
+
+	bool ShouldForceManualDriveState() {
+		return !ShouldAllowNativeAutoShifting();
+	}
+}
+
+bool GetIsInAuto(const Vehicle* veh) {
+	std::lock_guard<std::recursive_mutex> lock(transmissionMutex);
+	if (veh == nullptr) {
+		return false;
+	}
+
+	EnsureActiveTransmissionStateForVehicleUnlocked(const_cast<Vehicle*>(veh));
+	return UsesDefaultPower(activeTransmissionState);
+}
+
+void SetIsInAuto(const Vehicle* veh, bool value) {
+	std::lock_guard<std::recursive_mutex> lock(transmissionMutex);
+	Vehicle* vehicle = const_cast<Vehicle*>(veh);
+	if (!EnsureActiveTransmissionStateForVehicleUnlocked(vehicle)) {
+		return;
+	}
+
+	if (value) {
+		activeTransmissionState.Mode = TransmissionMode::Default;
+		activeTransmissionState.PowerCoef = PowerCoefDefaultGear;
+		return;
+	}
+
+	activeTransmissionState.Mode = TransmissionMode::Low;
+	activeTransmissionState.PowerCoef = PowerCoefLowGear;
+	activeTransmissionState.RequestedGear = 1;
+}
+
+void SetDefaultGearState(const Vehicle* veh) {
+	std::lock_guard<std::recursive_mutex> lock(transmissionMutex);
+	Vehicle* vehicle = const_cast<Vehicle*>(veh);
+	if (!EnsureActiveTransmissionStateForVehicleUnlocked(vehicle)) {
+		return;
+	}
+
+	activeTransmissionState.Mode = TransmissionMode::Default;
+	activeTransmissionState.PowerCoef = PowerCoefDefaultGear;
+}
+
+void SyncVehicleStateFromTruckAction(Vehicle* veh) {
+	std::lock_guard<std::recursive_mutex> lock(transmissionMutex);
+	SyncActiveTransmissionStateFromVehicleUnlocked(veh);
+	DebugLogMessage(
+		"SyncVehicleState",
+		"veh", static_cast<const void*>(veh),
+		"gear", veh != nullptr && veh->TruckAction != nullptr ? veh->TruckAction->Gear_1 : 0,
+		"power", veh != nullptr && veh->TruckAction != nullptr ? veh->TruckAction->PowerCoef : 0.0f,
+		"mode", TransmissionModeName(activeTransmissionState.Mode),
+		"requested", activeTransmissionState.RequestedGear
+	);
+}
 
 void Vehicle::SetPowerCoef(float coef) { Hooked_SetPowerCoef(this, coef); }
 
@@ -15,83 +352,160 @@ std::int32_t Vehicle::GetMaxGear() const {
 }
 
 bool Vehicle::ShiftToGear(std::int32_t targetGear, float powerCoef) {
-	if (targetGear != 99) {
-		targetGear = std::clamp(targetGear, -1, GetMaxGear());
+	std::lock_guard<std::recursive_mutex> lock(transmissionMutex);
+	DebugLogMessage(
+		"ShiftToGearRequest",
+		"veh", static_cast<const void*>(this),
+		"target", targetGear,
+		"power", powerCoef,
+		"immersive", GetRuntimeOption(RuntimeOption::ImmersiveMode)
+	);
+
+	if (IsInNativeAutoState(this)) {
+		DebugLogMessage(
+			"IgnoreModShiftInNativeAuto",
+			"veh", static_cast<const void*>(this),
+			"action", "ShiftToGear",
+			"target", targetGear
+		);
+		return false;
+	}
+
+	const bool wantsLowGear = targetGear == 1 && ApproximatelyEqual(powerCoef, PowerCoefLowGear);
+	const bool wantsLowPlusGear = targetGear == 1 && ApproximatelyEqual(powerCoef, PowerCoefLowPlusGear);
+	const bool wantsLowMinusGear = targetGear == 1 && ApproximatelyEqual(powerCoef, PowerCoefLowMinusGear);
+
+	if (GetRuntimeOption(RuntimeOption::ImmersiveMode) && (wantsLowGear || wantsLowPlusGear || wantsLowMinusGear)) {
+		return true;
+	}
+
+	if (wantsLowGear) {
+		SetLowRequestedGearUnlocked(this, TransmissionMode::Low, PowerCoefLowGear);
+	}
+	else if (wantsLowPlusGear) {
+		SetLowRequestedGearUnlocked(this, TransmissionMode::LowPlus, PowerCoefLowPlusGear);
+	}
+	else if (wantsLowMinusGear) {
+		SetLowRequestedGearUnlocked(this, TransmissionMode::LowMinus, PowerCoefLowMinusGear);
 	}
 	else {
-		targetGear = GetMaxGear() + 1;
-	}
-
-	if (iniConfig["OPTIONS"]["IMMERSIVE MODE"].as<bool>()) {
-		if (IsInAuto[this] == false) {
-			return true;
+		if (GetRuntimeOption(RuntimeOption::ImmersiveMode)) {
+			targetGear = std::clamp(targetGear, 1, GetMaxGear());
 		}
-		targetGear = std::clamp(targetGear, 1, GetMaxGear());
+
+		SetDefaultRequestedGearUnlocked(this, targetGear);
 	}
 
-	bool bSwitched = Hooked_ShiftGear(this, targetGear);
-
-	if (bSwitched) {
-		SetPowerCoef(powerCoef);
-	}
-
-	return bSwitched;
+	return ApplyActiveTransmissionStateUnlocked(this);
 }
 
 bool Vehicle::ShiftToNextGear() {
-	std::int32_t gear = TruckAction->Gear_1 + 1;
-
-	if (gear == 0 && iniConfig["OPTIONS"]["SKIP NEUTRAL"].as<bool>()) {
-		gear = 1;
+	std::lock_guard<std::recursive_mutex> lock(transmissionMutex);
+	if (!EnsureActiveTransmissionStateForVehicleUnlocked(this)) {
+		return false;
 	}
 
-	return ShiftToGear(std::min(gear, GetMaxGear()));
+	if (IsInNativeAutoState(this)) {
+		DebugLogMessage(
+			"IgnoreModShiftInNativeAuto",
+			"veh", static_cast<const void*>(this),
+			"action", "ShiftToNextGear",
+			"current", this->TruckAction != nullptr ? this->TruckAction->Gear_1 : 0
+		);
+		return false;
+	}
+
+	const std::int32_t maxGear = GetMaxGear();
+	std::int32_t currentGear = CurrentLogicalGearUnlocked(this);
+	if (currentGear > maxGear) {
+		currentGear = maxGear;
+	}
+
+	std::int32_t nextGear = currentGear + 1;
+	if (nextGear == 0 && GetRuntimeOption(RuntimeOption::SkipNeutral)) {
+		nextGear = 1;
+	}
+
+	DebugLogMessage(
+		"ShiftUpRequest",
+		"veh", static_cast<const void*>(this),
+		"current", currentGear,
+		"next", nextGear
+	);
+	SetDefaultRequestedGearUnlocked(this, std::min(nextGear, maxGear));
+	return ApplyActiveTransmissionStateUnlocked(this);
 }
 
 bool Vehicle::ShiftToPrevGear() {
-	std::int32_t gear = TruckAction->Gear_1 - 1;
-
-	if (gear == 0 && iniConfig["OPTIONS"]["SKIP NEUTRAL"].as<bool>()) {
-		gear = -1;
+	std::lock_guard<std::recursive_mutex> lock(transmissionMutex);
+	if (!EnsureActiveTransmissionStateForVehicleUnlocked(this)) {
+		return false;
 	}
 
-	if (iniConfig["OPTIONS"]["IMMERSIVE MODE"].as<bool>()) {
-		gear = std::max(gear, 1);
+	if (IsInNativeAutoState(this)) {
+		DebugLogMessage(
+			"IgnoreModShiftInNativeAuto",
+			"veh", static_cast<const void*>(this),
+			"action", "ShiftToPrevGear",
+			"current", this->TruckAction != nullptr ? this->TruckAction->Gear_1 : 0
+		);
+		return false;
 	}
 
-	return ShiftToGear(std::max(gear, -1));
+	const std::int32_t maxGear = GetMaxGear();
+	const std::int32_t currentGear = CurrentLogicalGearUnlocked(this);
+	std::int32_t prevGear = currentGear > maxGear ? maxGear : currentGear - 1;
+
+	if (prevGear == 0 && GetRuntimeOption(RuntimeOption::SkipNeutral)) {
+		prevGear = -1;
+	}
+
+	if (GetRuntimeOption(RuntimeOption::ImmersiveMode)) {
+		prevGear = std::max(prevGear, 1);
+	}
+
+	DebugLogMessage(
+		"ShiftDownRequest",
+		"veh", static_cast<const void*>(this),
+		"current", currentGear,
+		"prev", prevGear
+	);
+	SetDefaultRequestedGearUnlocked(this, std::max(prevGear, -1));
+	return ApplyActiveTransmissionStateUnlocked(this);
 }
 
 bool Vehicle::ShiftToHighGear() {
-	IsInAuto[this] = true;
-	return ShiftToGear(99);
+	return ShiftToGear(99, PowerCoefDefaultGear);
 }
 
 bool Vehicle::ShiftToReverseGear() {
-	IsInAuto[this] = true;
-	return ShiftToGear(-1);
+	return ShiftToGear(-1, PowerCoefDefaultGear);
 }
 
 bool Vehicle::ShiftToLowGear() {
-	IsInAuto[this] = false;
-	currentCoef = PowerCoefLowGear;
 	return ShiftToGear(1, PowerCoefLowGear);
 }
 
 bool Vehicle::ShiftToLowPlusGear() {
-	IsInAuto[this] = false;
-	currentCoef = PowerCoefLowPlusGear;
 	return ShiftToGear(1, PowerCoefLowPlusGear);
 }
 
 bool Vehicle::ShiftToLowMinusGear() {
-	IsInAuto[this] = false;
-	currentCoef = PowerCoefLowMinusGear;
 	return ShiftToGear(1, PowerCoefLowMinusGear);
 }
 
 bool Hooked_ShiftGear(Vehicle* veh, std::int32_t gear) {
-	bool result = ShiftGearO(veh, gear);
+	std::lock_guard<std::recursive_mutex> lock(transmissionMutex);
+	if (ShouldBlockGameShifting()) {
+		EnsureActiveTransmissionStateForVehicleUnlocked(veh);
+		DebugLogMessage("BlockGameShiftGear", "veh", static_cast<const void*>(veh), "gear", gear);
+		MirrorManualGearState(veh, CurrentRequestedTargetGearUnlocked(veh));
+		return false;
+	}
+
+	DebugLogMessage("PassGameShiftGear", "veh", static_cast<const void*>(veh), "gear", gear);
+	const bool result = ShiftGearO(veh, gear);
+	SyncActiveTransmissionStateFromVehicleUnlocked(veh);
 	return result;
 }
 
@@ -100,78 +514,120 @@ std::int32_t Hooked_GetMaxGear(const Vehicle* veh) {
 }
 
 void Hooked_ShiftToAutoGear(Vehicle* veh) {
-	veh->TruckAction->IsInAutoMode = false;
-
-	if (iniConfig["OPTIONS"]["DISABLE GAME SHIFTING"].as<bool>()) {
+	std::lock_guard<std::recursive_mutex> lock(transmissionMutex);
+	if (ShouldBlockGameShifting()) {
+		DebugLogMessage("BlockShiftToAuto", "veh", static_cast<const void*>(veh));
+		EnforceActiveTransmissionStateUnlocked(veh);
 		return;
 	}
 
-	IsInAuto[veh] = true;
-
-	if (veh->TruckAction->Gear_1 == (GetMaxGearO(veh) + 1)) {
-		veh->ShiftToGear(round(veh->GetMaxGear() * 0.8), 1.0f);
-	}
-	else if (veh->TruckAction->Gear_1 <= 1) {
-		veh->ShiftToGear(1, 1.05f);
-	}
-	if (!iniConfig["OPTIONS"]["REQUIRE CLUTCH"].as<bool>() && !iniConfig["OPTIONS"]["IMMERSIVE MODE"].as<bool>()) {
+	if (ShouldAllowNativeAutoShifting()) {
+		DebugLogMessage("AllowNativeAuto", "veh", static_cast<const void*>(veh));
 		ShiftToAutoGearO(veh);
+		SyncActiveTransmissionStateFromVehicleUnlocked(veh);
+		return;
+	}
+
+	DebugLogMessage("ForceManualAutoPath", "veh", static_cast<const void*>(veh));
+	SyncActiveTransmissionStateFromVehicleUnlocked(veh);
+	if (veh != nullptr && veh->TruckAction != nullptr) {
+		veh->TruckAction->IsInAutoMode = false;
 	}
 }
 
 bool Hooked_ShiftToReverse(Vehicle* veh) {
-	if (iniConfig["OPTIONS"]["DISABLE GAME SHIFTING"].as<bool>()) {
+	std::lock_guard<std::recursive_mutex> lock(transmissionMutex);
+	if (ShouldBlockGameShifting()) {
+		EnforceActiveTransmissionStateUnlocked(veh);
 		return false;
 	}
 
-	return ShiftToReverseO(veh);
+	const bool result = ShiftToReverseO(veh);
+	SyncActiveTransmissionStateFromVehicleUnlocked(veh);
+	if (ShouldForceManualDriveState()) {
+		veh->TruckAction->IsInAutoMode = false;
+	}
+	return result;
 }
 
 bool Hooked_ShiftToNeutral(Vehicle* veh) {
-	if (iniConfig["OPTIONS"]["DISABLE GAME SHIFTING"].as<bool>()) {
+	std::lock_guard<std::recursive_mutex> lock(transmissionMutex);
+	if (ShouldBlockGameShifting()) {
+		EnforceActiveTransmissionStateUnlocked(veh);
 		return false;
 	}
 
-	return ShiftToNeutralO(veh);
+	const bool result = ShiftToNeutralO(veh);
+	SyncActiveTransmissionStateFromVehicleUnlocked(veh);
+	if (ShouldForceManualDriveState()) {
+		veh->TruckAction->IsInAutoMode = false;
+	}
+	return result;
 }
 
 bool Hooked_ShiftToHigh(Vehicle* veh) {
-	if (iniConfig["OPTIONS"]["DISABLE GAME SHIFTING"].as<bool>()) {
+	std::lock_guard<std::recursive_mutex> lock(transmissionMutex);
+	if (ShouldBlockGameShifting()) {
+		EnforceActiveTransmissionStateUnlocked(veh);
 		return false;
 	}
 
-	return ShiftToHighO(veh);
+	const bool result = ShiftToHighO(veh);
+	SyncActiveTransmissionStateFromVehicleUnlocked(veh);
+	if (ShouldForceManualDriveState()) {
+		veh->TruckAction->IsInAutoMode = false;
+	}
+	return result;
 }
 
 bool Hooked_DisableAutoAndShift(Vehicle* veh, std::int32_t gear) {
-	if (iniConfig["OPTIONS"]["DISABLE GAME SHIFTING"].as<bool>()) {
+	std::lock_guard<std::recursive_mutex> lock(transmissionMutex);
+	if (ShouldBlockGameShifting()) {
+		EnforceActiveTransmissionStateUnlocked(veh);
 		return false;
 	}
 
-	bool result = DisableAutoAndShiftO(veh, gear);
-	IsInAuto[veh] = false;
+	const bool result = DisableAutoAndShiftO(veh, gear);
+	SyncActiveTransmissionStateFromVehicleUnlocked(veh);
+	if (ShouldForceManualDriveState()) {
+		veh->TruckAction->IsInAutoMode = false;
+	}
 	return result;
 }
 
 void Hooked_SetPowerCoef(Vehicle* veh, float coef) {
-	if (iniConfig["OPTIONS"]["DISABLE GAME SHIFTING"].as<bool>()) {
-		coef = currentCoef;
+	std::lock_guard<std::recursive_mutex> lock(transmissionMutex);
+	if (ShouldBlockGameShifting()) {
+		DebugLogMessage("BlockSetPowerCoef", "veh", static_cast<const void*>(veh), "requested_coef", coef);
+		EnforceActiveTransmissionStateUnlocked(veh);
+		return;
 	}
-	if (IsInAuto[veh]) {
-		coef = 1.05;
-	}
+
+	DebugLogMessage("PassSetPowerCoef", "veh", static_cast<const void*>(veh), "coef", coef);
 	SetPowerCoefO(veh, coef);
-	ShiftGearO(veh, veh->TruckAction->Gear_2);
+	SyncActiveTransmissionStateFromVehicleUnlocked(veh);
 }
 
 void Hooked_SetCurrentVehicle(combine_TRUCK_CONTROL* truckCtrl, Vehicle* veh) {
 	range = 0;
-	if (veh) {
-		IsInAuto[veh] = veh->TruckAction->IsInAutoMode;
-		if (IsInAuto[veh]) {
-			veh->ShiftToGear(1, 1.05);
-		}
+	SetCurrentVehicleO(truckCtrl, veh);
+
+	std::lock_guard<std::recursive_mutex> lock(transmissionMutex);
+	SyncActiveTransmissionStateFromVehicleUnlocked(veh);
+	DebugLogMessage(
+		"SetCurrentVehicle",
+		"veh", static_cast<const void*>(veh),
+		"block_game_shifting", ShouldBlockGameShifting(),
+		"allow_native_auto", ShouldAllowNativeAutoShifting(),
+		"gear", veh != nullptr && veh->TruckAction != nullptr ? veh->TruckAction->Gear_1 : 0,
+		"power", veh != nullptr && veh->TruckAction != nullptr ? veh->TruckAction->PowerCoef : 0.0f
+	);
+	if (ShouldBlockGameShifting()) {
+		EnforceActiveTransmissionStateUnlocked(veh);
+		return;
+	}
+
+	if (ShouldForceManualDriveState() && veh != nullptr && veh->TruckAction != nullptr) {
 		veh->TruckAction->IsInAutoMode = false;
 	}
-	SetCurrentVehicleO(truckCtrl, veh);
 }

--- a/DLL/game_data.h
+++ b/DLL/game_data.h
@@ -4,6 +4,7 @@
 inline const float PowerCoefLowGear = .45f;
 inline const float PowerCoefLowPlusGear = 1.f;
 inline const float PowerCoefLowMinusGear = .2f;
+inline const float PowerCoefDefaultGear = 1.05f;
 
 class String {
 public:
@@ -219,4 +220,7 @@ public:
 	char pad_0000[1032]; // 0x0000
 };                     // Size: 0x0408
 
-extern std::unordered_map <Vehicle*, std::atomic<bool>> IsInAuto;
+extern bool GetIsInAuto(const Vehicle* veh);
+extern void SetIsInAuto(const Vehicle* veh, bool value);
+extern void SetDefaultGearState(const Vehicle* veh);
+extern void SyncVehicleStateFromTruckAction(Vehicle* veh);

--- a/DLL/gui.cpp
+++ b/DLL/gui.cpp
@@ -214,16 +214,11 @@ HRESULT __stdcall hookedPresent(IDXGISwapChain* pSwapChain, UINT SyncInterval, U
 				ImGui::TableSetColumnIndex(1);
 				std::string buttonText = entry.second.as<std::string>() + "##" + std::to_string(++count);
 				if (ImGui::Button(buttonText.c_str())) {
-					iniConfig["KEYBOARD"][entry.first] = "LISTENING";
+					SetBindingValue("KEYBOARD", entry.first, "LISTENING");
 					ClearTempPressed();
 				}
 				if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
-					if (entry.second.as<std::string>() == "LISTENING") {
-						iniConfig["KEYBOARD"][entry.first] = "FOUND";
-					}
-					else {
-						iniConfig["KEYBOARD"][entry.first] = "NONE";
-					}
+					SetBindingValue("KEYBOARD", entry.first, "NONE");
 				}
 			}
 			ImGui::EndTable();
@@ -245,16 +240,11 @@ HRESULT __stdcall hookedPresent(IDXGISwapChain* pSwapChain, UINT SyncInterval, U
 				ImGui::TableSetColumnIndex(1);
 				std::string buttonText = entry.second.as<std::string>() + "##" + std::to_string(++count);
 				if (ImGui::Button(buttonText.c_str())) {
-					iniConfig["CONTROLLER"][entry.first] = "LISTENING";
+					SetBindingValue("CONTROLLER", entry.first, "LISTENING");
 					ClearTempPressed();
 				}
 				if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
-					if (entry.second.as<std::string>() == "LISTENING") {
-						iniConfig["CONTROLLER"][entry.first] = "FOUND";
-					}
-					else {
-						iniConfig["CONTROLLER"][entry.first] = "NONE";
-					}
+					SetBindingValue("CONTROLLER", entry.first, "NONE");
 				}
 			}
 			ImGui::EndTable();
@@ -274,8 +264,10 @@ HRESULT __stdcall hookedPresent(IDXGISwapChain* pSwapChain, UINT SyncInterval, U
 				ImGui::Dummy(ImVec2(0, 0.1f));
 				ImGui::Text(entry.first.c_str());
 				ImGui::TableSetColumnIndex(1);
-				if (ImGui::Button(entry.second.as<bool>() ? std::string("True##" + entry.first).c_str() : std::string("False##" + entry.first).c_str())) {
-					iniConfig["OPTIONS"][entry.first] = !entry.second.as<bool>();
+				bool optionValue = GetRuntimeOptionValue(entry.first);
+				if (ImGui::Button(optionValue ? std::string("True##" + entry.first).c_str() : std::string("False##" + entry.first).c_str())) {
+					SetRuntimeOptionValue(entry.first, !optionValue);
+					SaveIniConfig();
 				}
 			}
 

--- a/DLL/gui.cpp
+++ b/DLL/gui.cpp
@@ -215,7 +215,7 @@ HRESULT __stdcall hookedPresent(IDXGISwapChain* pSwapChain, UINT SyncInterval, U
 				std::string buttonText = entry.second.as<std::string>() + "##" + std::to_string(++count);
 				if (ImGui::Button(buttonText.c_str())) {
 					iniConfig["KEYBOARD"][entry.first] = "LISTENING";
-					tempPressed.clear();
+					ClearTempPressed();
 				}
 				if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
 					if (entry.second.as<std::string>() == "LISTENING") {
@@ -246,7 +246,7 @@ HRESULT __stdcall hookedPresent(IDXGISwapChain* pSwapChain, UINT SyncInterval, U
 				std::string buttonText = entry.second.as<std::string>() + "##" + std::to_string(++count);
 				if (ImGui::Button(buttonText.c_str())) {
 					iniConfig["CONTROLLER"][entry.first] = "LISTENING";
-					tempPressed.clear();
+					ClearTempPressed();
 				}
 				if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
 					if (entry.second.as<std::string>() == "LISTENING") {
@@ -287,7 +287,7 @@ HRESULT __stdcall hookedPresent(IDXGISwapChain* pSwapChain, UINT SyncInterval, U
 			SaveIniConfig();
 		}
 		ImGui::SameLine();
-		ImGui::Text("To change keybind left click on it, press desired keys/buttons/axis and right click to confirm. Use right click to clear a keybind.");
+		ImGui::Text("To change a keybind left click on it and press the desired key/button/axis. Use right click to clear a keybind.");
 		//ImGui::SameLine();
 		//ImGui::InvisibleButton("##debug_separator", ImVec2(width * 0.43f, ImGui::GetItemRectSize().y));
 		//ImGui::SameLine();

--- a/DLL/input.cpp
+++ b/DLL/input.cpp
@@ -4,6 +4,8 @@
 #include "gui.h"
 #include "game_data.h"
 #include "memory.h"
+#include <mutex>
+#include <Xinput.h>
 
 extern std::unordered_map <Vehicle*, std::atomic<bool>> IsInAuto;
 
@@ -17,6 +19,138 @@ std::set<std::string> tempPressed;
 std::unordered_map<std::string, bool> wasPressedKb;
 std::unordered_map<std::string, bool> wasPressedJoy;
 std::atomic<int32_t> range = 0;
+
+std::string abbreviate(const std::string& input);
+
+namespace {
+	constexpr int32_t CONTROLLER_AXIS_THRESHOLD = 20000;
+	std::mutex tempPressedMutex;
+
+	enum class InputGroup {
+		Keyboard,
+		Controller
+	};
+
+	std::set<std::string> tempPressedKeyboard;
+	std::set<std::string> tempPressedController;
+
+	std::set<std::string>& TempPressedFor(InputGroup group) {
+		return group == InputGroup::Keyboard ? tempPressedKeyboard : tempPressedController;
+	}
+
+	void AddTempPressed(InputGroup group, const std::string& entry) {
+		std::lock_guard<std::mutex> lock(tempPressedMutex);
+		TempPressedFor(group).emplace(entry);
+	}
+
+	void SetPressed(InputGroup group, const std::string& entry, bool pressed) {
+		if (pressed && !currentlyPressed[entry]) {
+			AddTempPressed(group, entry);
+		}
+		currentlyPressed[entry] = pressed;
+	}
+
+	std::string ControllerPrefix(const OIS::Object* device) {
+		return abbreviate(device->vendor());
+	}
+
+	std::string ConsumeTempPressed(InputGroup group, bool noneWhenEmpty = true) {
+		std::lock_guard<std::mutex> lock(tempPressedMutex);
+		std::set<std::string>& tempPressedSet = TempPressedFor(group);
+		if (tempPressedSet.empty()) {
+			return noneWhenEmpty ? "NONE" : "";
+		}
+
+		std::string tempStr;
+		for (const auto& key : tempPressedSet) {
+			tempStr += key;
+			tempStr += "+";
+		}
+		tempStr.pop_back();
+		tempPressedSet.clear();
+		return tempStr;
+	}
+
+	void PollJoyStickState(const OIS::JoyStick* joystick) {
+		const std::string controller = ControllerPrefix(joystick);
+		const OIS::JoyStickState& state = joystick->getJoyStickState();
+
+		for (size_t button = 0; button < state.mButtons.size(); ++button) {
+			SetPressed(InputGroup::Controller, controller + ".b." + std::to_string(button), state.mButtons[button]);
+		}
+
+		for (size_t axis = 0; axis < state.mAxes.size(); ++axis) {
+			SetPressed(InputGroup::Controller, controller + ".a." + std::to_string(axis) + ".p", state.mAxes[axis].abs > CONTROLLER_AXIS_THRESHOLD);
+			SetPressed(InputGroup::Controller, controller + ".a." + std::to_string(axis) + ".n", state.mAxes[axis].abs < -CONTROLLER_AXIS_THRESHOLD);
+		}
+
+		for (int32_t slider = 0; slider < 4; ++slider) {
+			SetPressed(InputGroup::Controller, controller + ".s.x." + std::to_string(slider) + ".p", state.mSliders[slider].abX > CONTROLLER_AXIS_THRESHOLD);
+			SetPressed(InputGroup::Controller, controller + ".s.x." + std::to_string(slider) + ".n", state.mSliders[slider].abX < -CONTROLLER_AXIS_THRESHOLD);
+			SetPressed(InputGroup::Controller, controller + ".s.y." + std::to_string(slider) + ".p", state.mSliders[slider].abY > CONTROLLER_AXIS_THRESHOLD);
+			SetPressed(InputGroup::Controller, controller + ".s.y." + std::to_string(slider) + ".n", state.mSliders[slider].abY < -CONTROLLER_AXIS_THRESHOLD);
+		}
+
+		for (int32_t pov = 0; pov < 4; ++pov) {
+			SetPressed(InputGroup::Controller, controller + ".p." + std::to_string(pov) + ".up", (state.mPOV[pov].direction & OIS::Pov::North) != 0);
+			SetPressed(InputGroup::Controller, controller + ".p." + std::to_string(pov) + ".down", (state.mPOV[pov].direction & OIS::Pov::South) != 0);
+			SetPressed(InputGroup::Controller, controller + ".p." + std::to_string(pov) + ".right", (state.mPOV[pov].direction & OIS::Pov::East) != 0);
+			SetPressed(InputGroup::Controller, controller + ".p." + std::to_string(pov) + ".left", (state.mPOV[pov].direction & OIS::Pov::West) != 0);
+		}
+	}
+
+	void SetXInputButton(DWORD userIndex, const std::string& name, WORD buttons, WORD mask) {
+		SetPressed(InputGroup::Controller, "Xi." + std::to_string(userIndex) + ".b." + name, (buttons & mask) != 0);
+	}
+
+	void SetXInputAxis(DWORD userIndex, const std::string& name, int32_t value) {
+		SetPressed(InputGroup::Controller, "Xi." + std::to_string(userIndex) + ".a." + name + ".p", value > CONTROLLER_AXIS_THRESHOLD);
+		SetPressed(InputGroup::Controller, "Xi." + std::to_string(userIndex) + ".a." + name + ".n", value < -CONTROLLER_AXIS_THRESHOLD);
+	}
+
+	void PollXInputController(DWORD userIndex) {
+		XINPUT_STATE state = {};
+		const bool connected = XInputGetState(userIndex, &state) == ERROR_SUCCESS;
+		const WORD buttons = connected ? state.Gamepad.wButtons : 0;
+		const BYTE leftTrigger = connected ? state.Gamepad.bLeftTrigger : 0;
+		const BYTE rightTrigger = connected ? state.Gamepad.bRightTrigger : 0;
+
+		SetXInputButton(userIndex, "DU", buttons, XINPUT_GAMEPAD_DPAD_UP);
+		SetXInputButton(userIndex, "DD", buttons, XINPUT_GAMEPAD_DPAD_DOWN);
+		SetXInputButton(userIndex, "DL", buttons, XINPUT_GAMEPAD_DPAD_LEFT);
+		SetXInputButton(userIndex, "DR", buttons, XINPUT_GAMEPAD_DPAD_RIGHT);
+		SetXInputButton(userIndex, "START", buttons, XINPUT_GAMEPAD_START);
+		SetXInputButton(userIndex, "BACK", buttons, XINPUT_GAMEPAD_BACK);
+		SetXInputButton(userIndex, "LS", buttons, XINPUT_GAMEPAD_LEFT_THUMB);
+		SetXInputButton(userIndex, "RS", buttons, XINPUT_GAMEPAD_RIGHT_THUMB);
+		SetXInputButton(userIndex, "LB", buttons, XINPUT_GAMEPAD_LEFT_SHOULDER);
+		SetXInputButton(userIndex, "RB", buttons, XINPUT_GAMEPAD_RIGHT_SHOULDER);
+		SetXInputButton(userIndex, "A", buttons, XINPUT_GAMEPAD_A);
+		SetXInputButton(userIndex, "B", buttons, XINPUT_GAMEPAD_B);
+		SetXInputButton(userIndex, "X", buttons, XINPUT_GAMEPAD_X);
+		SetXInputButton(userIndex, "Y", buttons, XINPUT_GAMEPAD_Y);
+
+		SetPressed(InputGroup::Controller, "Xi." + std::to_string(userIndex) + ".t.L", leftTrigger > XINPUT_GAMEPAD_TRIGGER_THRESHOLD);
+		SetPressed(InputGroup::Controller, "Xi." + std::to_string(userIndex) + ".t.R", rightTrigger > XINPUT_GAMEPAD_TRIGGER_THRESHOLD);
+
+		SetXInputAxis(userIndex, "LX", connected ? state.Gamepad.sThumbLX : 0);
+		SetXInputAxis(userIndex, "LY", connected ? state.Gamepad.sThumbLY : 0);
+		SetXInputAxis(userIndex, "RX", connected ? state.Gamepad.sThumbRX : 0);
+		SetXInputAxis(userIndex, "RY", connected ? state.Gamepad.sThumbRY : 0);
+	}
+
+	void PollXInputControllers() {
+		for (DWORD userIndex = 0; userIndex < XUSER_MAX_COUNT; ++userIndex) {
+			PollXInputController(userIndex);
+		}
+	}
+}
+
+void ClearTempPressed() {
+	std::lock_guard<std::mutex> lock(tempPressedMutex);
+	tempPressedKeyboard.clear();
+	tempPressedController.clear();
+}
 
 std::unordered_map<std::string, std::function<void()>> bindFunctions = {
 	{ "GEAR 1",[]() { if (auto veh = GetCurrentVehicle()) { IsInAuto[veh] = true; veh->ShiftToGear(1); } }},
@@ -65,161 +199,62 @@ namespace SMT {
 
 	bool KeyListener::keyPressed(const OIS::KeyEvent& e) {
 		std::string entry = "Kb." + std::to_string(e.key);
-		if (!currentlyPressed[entry]) {
-			tempPressed.emplace(entry);
-		}
-		currentlyPressed[entry] = true;
+		SetPressed(InputGroup::Keyboard, entry, true);
 		return true;
 	}
 
 	bool KeyListener::keyReleased(const OIS::KeyEvent& e) {
-		currentlyPressed["Kb." + std::to_string(e.key)] = false;
+		SetPressed(InputGroup::Keyboard, "Kb." + std::to_string(e.key), false);
 		return true;
 	}
 
 	bool JoyStickListener::buttonPressed(const OIS::JoyStickEvent& e, int button) {
-		std::string entry = abbreviate(e.device->vendor()) + ".b." + std::to_string(button);
-		if (!currentlyPressed[entry]) {
-			tempPressed.emplace(entry);
-		}
-		currentlyPressed[entry] = true;
+		std::string entry = ControllerPrefix(e.device) + ".b." + std::to_string(button);
+		SetPressed(InputGroup::Controller, entry, true);
 		return true;
 	}
 
 	bool JoyStickListener::buttonReleased(const OIS::JoyStickEvent& e, int button) {
-		currentlyPressed[abbreviate(e.device->vendor()) + ".b." + std::to_string(button)] = false;
+		SetPressed(InputGroup::Controller, ControllerPrefix(e.device) + ".b." + std::to_string(button), false);
 		return true;
 	}
 
 	bool JoyStickListener::axisMoved(const OIS::JoyStickEvent& e, int axis) {
-		if (e.state.mAxes[axis].abs > 20000) {
-			std::string entry = abbreviate(e.device->vendor()) + ".a." + std::to_string(axis) + ".p";
-			if (!currentlyPressed[entry]) {
-				tempPressed.emplace(entry);
-			}
-			currentlyPressed[entry] = true;
-		}
-		else {
-			currentlyPressed[abbreviate(e.device->vendor()) + ".a." + std::to_string(axis) + ".p"] = false;
-		}
-		if (e.state.mAxes[axis].abs < -20000) {
-			std::string entry = abbreviate(e.device->vendor()) + ".a." + std::to_string(axis) + ".n";
-			if (!currentlyPressed[entry]) {
-				tempPressed.emplace(entry);
-			}
-			currentlyPressed[entry] = true;
-		}
-		else {
-			currentlyPressed[abbreviate(e.device->vendor()) + ".a." + std::to_string(axis) + ".n"] = false;
-		}
+		std::string controller = ControllerPrefix(e.device);
+		SetPressed(InputGroup::Controller, controller + ".a." + std::to_string(axis) + ".p", e.state.mAxes[axis].abs > CONTROLLER_AXIS_THRESHOLD);
+		SetPressed(InputGroup::Controller, controller + ".a." + std::to_string(axis) + ".n", e.state.mAxes[axis].abs < -CONTROLLER_AXIS_THRESHOLD);
 		return true;
 	}
 
 	bool JoyStickListener::sliderMoved(const OIS::JoyStickEvent& e, int sliderID) {
-		if (e.state.mSliders[sliderID].abX > 20000) {
-			std::string entry = abbreviate(e.device->vendor()) + ".s.x." + std::to_string(sliderID) + ".p";
-			if (!currentlyPressed[entry]) {
-				tempPressed.emplace(entry);
-			}
-			currentlyPressed[entry] = true;
-		}
-		else {
-			currentlyPressed[abbreviate(e.device->vendor()) + ".s.x." + std::to_string(sliderID) + ".p"] = false;
-		}
-		if (e.state.mSliders[sliderID].abX < -20000) {
-			std::string entry = abbreviate(e.device->vendor()) + ".s.x." + std::to_string(sliderID) + ".n";
-			if (!currentlyPressed[entry]) {
-				tempPressed.emplace(entry);
-			}
-			currentlyPressed[entry] = true;
-		}
-		else {
-			currentlyPressed[abbreviate(e.device->vendor()) + ".s.x." + std::to_string(sliderID) + ".n"] = false;
-		}
-		if (e.state.mSliders[sliderID].abY > 20000) {
-			std::string entry = abbreviate(e.device->vendor()) + ".s.y." + std::to_string(sliderID) + ".p";
-			if (!currentlyPressed[entry]) {
-				tempPressed.emplace(entry);
-			}
-			currentlyPressed[entry] = true;
-		}
-		else {
-			currentlyPressed[abbreviate(e.device->vendor()) + ".s.y." + std::to_string(sliderID) + ".p"] = false;
-		}
-		if (e.state.mSliders[sliderID].abY < -20000) {
-			std::string entry = abbreviate(e.device->vendor()) + ".s.y." + std::to_string(sliderID) + ".n";
-			if (!currentlyPressed[entry]) {
-				tempPressed.emplace(entry);
-			}
-			currentlyPressed[entry] = true;
-		}
-		else {
-			currentlyPressed[abbreviate(e.device->vendor()) + ".s.y." + std::to_string(sliderID) + ".n"] = false;
-		}
+		std::string controller = ControllerPrefix(e.device);
+		SetPressed(InputGroup::Controller, controller + ".s.x." + std::to_string(sliderID) + ".p", e.state.mSliders[sliderID].abX > CONTROLLER_AXIS_THRESHOLD);
+		SetPressed(InputGroup::Controller, controller + ".s.x." + std::to_string(sliderID) + ".n", e.state.mSliders[sliderID].abX < -CONTROLLER_AXIS_THRESHOLD);
+		SetPressed(InputGroup::Controller, controller + ".s.y." + std::to_string(sliderID) + ".p", e.state.mSliders[sliderID].abY > CONTROLLER_AXIS_THRESHOLD);
+		SetPressed(InputGroup::Controller, controller + ".s.y." + std::to_string(sliderID) + ".n", e.state.mSliders[sliderID].abY < -CONTROLLER_AXIS_THRESHOLD);
 		return true;
 	}
 
 	bool JoyStickListener::povMoved(const OIS::JoyStickEvent& e, int pov) {
-		if ((e.state.mPOV[pov].direction & OIS::Pov::North) != 0) {
-			std::string entry = abbreviate(e.device->vendor()) + ".p." + std::to_string(pov) + ".up";
-			if (!currentlyPressed[entry]) {
-				tempPressed.emplace(entry);
-			}
-			currentlyPressed[entry] = true;
-		}
-		else {
-			currentlyPressed[abbreviate(e.device->vendor()) + ".p." + std::to_string(pov) + ".up"] = false;
-		}
-
-		if ((e.state.mPOV[pov].direction & OIS::Pov::South) != 0) {
-			std::string entry = abbreviate(e.device->vendor()) + ".p." + std::to_string(pov) + ".down";
-			if (!currentlyPressed[entry]) {
-				tempPressed.emplace(entry);
-			}
-			currentlyPressed[entry] = true;
-		}
-		else {
-			currentlyPressed[abbreviate(e.device->vendor()) + ".p." + std::to_string(pov) + ".down"] = false;
-		}
-
-		if ((e.state.mPOV[pov].direction & OIS::Pov::East) != 0) {
-			std::string entry = abbreviate(e.device->vendor()) + ".p." + std::to_string(pov) + ".right";
-			if (!currentlyPressed[entry]) {
-				tempPressed.emplace(entry);
-			}
-			currentlyPressed[entry] = true;
-		}
-		else {
-			currentlyPressed[abbreviate(e.device->vendor()) + ".p." + std::to_string(pov) + ".right"] = false;
-		}
-
-		if ((e.state.mPOV[pov].direction & OIS::Pov::West) != 0) {
-			std::string entry = abbreviate(e.device->vendor()) + ".p." + std::to_string(pov) + ".left";
-			if (!currentlyPressed[entry]) {
-				tempPressed.emplace(entry);
-			}
-			currentlyPressed[entry] = true;
-		}
-		else {
-			currentlyPressed[abbreviate(e.device->vendor()) + ".p." + std::to_string(pov) + ".left"] = false;
-		}
+		std::string controller = ControllerPrefix(e.device);
+		SetPressed(InputGroup::Controller, controller + ".p." + std::to_string(pov) + ".up", (e.state.mPOV[pov].direction & OIS::Pov::North) != 0);
+		SetPressed(InputGroup::Controller, controller + ".p." + std::to_string(pov) + ".down", (e.state.mPOV[pov].direction & OIS::Pov::South) != 0);
+		SetPressed(InputGroup::Controller, controller + ".p." + std::to_string(pov) + ".right", (e.state.mPOV[pov].direction & OIS::Pov::East) != 0);
+		SetPressed(InputGroup::Controller, controller + ".p." + std::to_string(pov) + ".left", (e.state.mPOV[pov].direction & OIS::Pov::West) != 0);
 		return true;
 	}
 
 	bool MouseListener::mousePressed(const OIS::MouseEvent& e, OIS::MouseButtonID button) {
 		std::string entry = "Ms." + std::to_string(button);
 		if ((int)button > 1) {
-			if (!currentlyPressed[entry]) {
-				tempPressed.emplace(entry);
-			}
-			currentlyPressed[entry] = true;
+			SetPressed(InputGroup::Keyboard, entry, true);
 		}
 		return true;
 	}
 
 	bool MouseListener::mouseReleased(const OIS::MouseEvent& e, OIS::MouseButtonID button) {
 		if ((int)button > 1) {
-			currentlyPressed["Ms." + std::to_string(button)] = false;
+			SetPressed(InputGroup::Keyboard, "Ms." + std::to_string(button), false);
 		}
 		return true;
 	}
@@ -240,35 +275,34 @@ DWORD WINAPI ProcessInput(LPVOID lpReserved) {
 			if (GetForegroundWindow() == window) {
 				for (auto& js : joystickList) {
 					js->capture();
+					PollJoyStickState(js);
 				}
 			}
+			PollXInputControllers();
 			mouse->capture();
 			bool goToNeutral = iniConfig["OPTIONS"]["REQUIRE GEAR HELD"].as<bool>();
 			for (auto action : iniConfig["KEYBOARD"]) {
 				bool pressed = true;
-				if (action.second.as<std::string>() == "FOUND") {
-					if (tempPressed.size() > 0) {
-						std::string tempStr = "";
-						for (auto key : tempPressed) {
-							tempStr += key;
-							tempStr += "+";
-						}
-						tempStr.pop_back();
-						iniConfig["KEYBOARD"][action.first] = tempStr;
+				std::string binding = action.second.as<std::string>();
+				if (binding == "FOUND") {
+					iniConfig["KEYBOARD"][action.first] = ConsumeTempPressed(InputGroup::Keyboard);
+				}
+				else if (binding == "LISTENING") {
+					std::string captured = ConsumeTempPressed(InputGroup::Keyboard, false);
+					if (!captured.empty()) {
+						iniConfig["KEYBOARD"][action.first] = captured;
 					}
-					else {
-						iniConfig["KEYBOARD"][action.first] = "NONE";
-					}
-					tempPressed.clear();
+					pressed = false;
 				}
 				else {
 					int32_t cnt = 0;
-					for (auto part : action.second.as<std::string>() | std::views::split('+')) {
+					for (auto part : binding | std::views::split('+')) {
 						cnt++;
 						if (!currentlyPressed[std::string(part.begin(), part.end())]) {
-							if (action.first.starts_with("GEAR") && action.second.as<std::string>() != "NONE") {
-								if ((std::string(part.begin(), part.end()) == iniConfig["KEYBOARD"]["RANGE HIGH"].as<std::string>() && range == 1) ||
-									(std::string(part.begin(), part.end()) == iniConfig["KEYBOARD"]["RANGE LOW"].as<std::string>() && range == -1)) {
+							std::string partStr(part.begin(), part.end());
+							if (action.first.starts_with("GEAR") && binding != "NONE") {
+								if ((partStr == iniConfig["KEYBOARD"]["RANGE HIGH"].as<std::string>() && range == 1) ||
+									(partStr == iniConfig["KEYBOARD"]["RANGE LOW"].as<std::string>() && range == -1)) {
 									continue;
 								}
 							}
@@ -288,29 +322,26 @@ DWORD WINAPI ProcessInput(LPVOID lpReserved) {
 			}
 			for (auto action : iniConfig["CONTROLLER"]) {
 				bool pressed = true;
-				if (action.second.as<std::string>() == "FOUND") {
-					if (tempPressed.size() > 0) {
-						std::string tempStr = "";
-						for (auto key : tempPressed) {
-							tempStr += key;
-							tempStr += "+";
-						}
-						tempStr.pop_back();
-						iniConfig["CONTROLLER"][action.first] = tempStr;
+				std::string binding = action.second.as<std::string>();
+				if (binding == "FOUND") {
+					iniConfig["CONTROLLER"][action.first] = ConsumeTempPressed(InputGroup::Controller);
+				}
+				else if (binding == "LISTENING") {
+					std::string captured = ConsumeTempPressed(InputGroup::Controller, false);
+					if (!captured.empty()) {
+						iniConfig["CONTROLLER"][action.first] = captured;
 					}
-					else {
-						iniConfig["CONTROLLER"][action.first] = "NONE";
-					}
-					tempPressed.clear();
+					pressed = false;
 				}
 				else {
 					int32_t cnt = 0;
-					for (auto part : action.second.as<std::string>() | std::views::split('+')) {
+					for (auto part : binding | std::views::split('+')) {
 						cnt++;
 						if (!currentlyPressed[std::string(part.begin(), part.end())]) {
-							if (action.first.starts_with("GEAR") && action.second.as<std::string>() != "NONE") {
-								if ((std::string(part.begin(), part.end()) == iniConfig["CONTROLLER"]["RANGE HIGH"].as<std::string>() && range == 1) ||
-									(std::string(part.begin(), part.end()) == iniConfig["CONTROLLER"]["RANGE LOW"].as<std::string>() && range == -1)) {
+							std::string partStr(part.begin(), part.end());
+							if (action.first.starts_with("GEAR") && binding != "NONE") {
+								if ((partStr == iniConfig["CONTROLLER"]["RANGE HIGH"].as<std::string>() && range == 1) ||
+									(partStr == iniConfig["CONTROLLER"]["RANGE LOW"].as<std::string>() && range == -1)) {
 									continue;
 								}
 							}

--- a/DLL/input.cpp
+++ b/DLL/input.cpp
@@ -7,8 +7,6 @@
 #include <mutex>
 #include <Xinput.h>
 
-extern std::unordered_map <Vehicle*, std::atomic<bool>> IsInAuto;
-
 OIS::InputManager* inputManager;
 std::atomic<bool> keepAliveInput = true;
 OIS::Keyboard* keyboard = nullptr;
@@ -153,7 +151,7 @@ void ClearTempPressed() {
 }
 
 std::unordered_map<std::string, std::function<void()>> bindFunctions = {
-	{ "GEAR 1",[]() { if (auto veh = GetCurrentVehicle()) { IsInAuto[veh] = true; veh->ShiftToGear(1); } }},
+	{ "GEAR 1",[]() { if (auto veh = GetCurrentVehicle()) veh->ShiftToGear(1); }},
 	{ "GEAR 2",[]() { if (auto veh = GetCurrentVehicle()) veh->ShiftToGear(2); } },
 	{ "GEAR 3",[]() { if (auto veh = GetCurrentVehicle()) veh->ShiftToGear(3); } },
 	{ "GEAR 4",[]() { if (auto veh = GetCurrentVehicle()) veh->ShiftToGear(4); } },
@@ -280,17 +278,17 @@ DWORD WINAPI ProcessInput(LPVOID lpReserved) {
 			}
 			PollXInputControllers();
 			mouse->capture();
-			bool goToNeutral = iniConfig["OPTIONS"]["REQUIRE GEAR HELD"].as<bool>();
+			bool goToNeutral = GetRuntimeOption(RuntimeOption::RequireGearHeld);
 			for (auto action : iniConfig["KEYBOARD"]) {
 				bool pressed = true;
 				std::string binding = action.second.as<std::string>();
 				if (binding == "FOUND") {
-					iniConfig["KEYBOARD"][action.first] = ConsumeTempPressed(InputGroup::Keyboard);
+					SetBindingValue("KEYBOARD", action.first, ConsumeTempPressed(InputGroup::Keyboard));
 				}
 				else if (binding == "LISTENING") {
 					std::string captured = ConsumeTempPressed(InputGroup::Keyboard, false);
 					if (!captured.empty()) {
-						iniConfig["KEYBOARD"][action.first] = captured;
+						SetBindingValue("KEYBOARD", action.first, captured);
 					}
 					pressed = false;
 				}
@@ -324,12 +322,12 @@ DWORD WINAPI ProcessInput(LPVOID lpReserved) {
 				bool pressed = true;
 				std::string binding = action.second.as<std::string>();
 				if (binding == "FOUND") {
-					iniConfig["CONTROLLER"][action.first] = ConsumeTempPressed(InputGroup::Controller);
+					SetBindingValue("CONTROLLER", action.first, ConsumeTempPressed(InputGroup::Controller));
 				}
 				else if (binding == "LISTENING") {
 					std::string captured = ConsumeTempPressed(InputGroup::Controller, false);
 					if (!captured.empty()) {
-						iniConfig["CONTROLLER"][action.first] = captured;
+						SetBindingValue("CONTROLLER", action.first, captured);
 					}
 					pressed = false;
 				}
@@ -360,8 +358,11 @@ DWORD WINAPI ProcessInput(LPVOID lpReserved) {
 				wasPressedJoy[action.first] = pressed;
 			}
 			for (auto fnc : functionsToRun) {
+				if (fnc.starts_with("GEAR") || fnc == "RANGE HIGH" || fnc == "RANGE LOW") {
+					DebugLogMessage("InputAction", fnc);
+				}
 				bindFunctions[fnc]();
-				if (iniConfig["OPTIONS"]["REQUIRE CLUTCH"].as<bool>()) {
+				if (GetRuntimeOption(RuntimeOption::RequireClutch)) {
 					if (auto veh = GetCurrentVehicle()) {
 						if (!wasPressedKb["CLUTCH"] && !wasPressedJoy["CLUTCH"]) {
 							if (fnc.starts_with("GEAR") && fnc != "GEAR N") {

--- a/DLL/input.h
+++ b/DLL/input.h
@@ -29,6 +29,7 @@ namespace SMT {
 
 extern void InitInput();
 extern void ShutdownInput();
+extern void ClearTempPressed();
 extern OIS::InputManager* inputManager;
 extern OIS::Keyboard* keyboard;
 extern OIS::Mouse* mouse;

--- a/DLL/memory.cpp
+++ b/DLL/memory.cpp
@@ -164,9 +164,12 @@ void InitMemory() {
 	DetourTransactionCommit();
 
 	if (Vehicle* veh = GetCurrentVehicle()) {
-		IsInAuto[veh] = veh->TruckAction->IsInAutoMode;
-		veh->TruckAction->IsInAutoMode = false;
-		veh->ShiftToGear(1, 1.05);
+		SyncVehicleStateFromTruckAction(veh);
+		if (GetRuntimeOption(RuntimeOption::DisableGameShifting)
+			|| GetRuntimeOption(RuntimeOption::ImmersiveMode)
+			|| GetRuntimeOption(RuntimeOption::RequireClutch)) {
+			veh->TruckAction->IsInAutoMode = false;
+		}
 	}
 
 	LogMessage("init", base);

--- a/DLL/shared.h
+++ b/DLL/shared.h
@@ -33,6 +33,7 @@
 #define STR(x) STR2(x)
 
 extern std::ofstream logFile;
+extern bool IsDebugLoggingEnabled();
 
 struct FastIO {
 	FastIO() {
@@ -75,3 +76,18 @@ inline void LogMessage(const T& first, const Args&... rest) {
 	logFile << '\n';
 }
 
+template<typename T>
+inline void DebugLogMessage(const T& msg) {
+	if (!IsDebugLoggingEnabled()) {
+		return;
+	}
+	LogMessage(msg);
+}
+
+template<typename T, typename... Args>
+inline void DebugLogMessage(const T& first, const Args&... rest) {
+	if (!IsDebugLoggingEnabled()) {
+		return;
+	}
+	LogMessage(first, rest...);
+}


### PR DESCRIPTION
Added Xbox controller support

Refactored the transmission system for more reliable manual shifting and cleaner separation from the game’s native auto gearbox.

Introduced a centralized transmission controller/state instead of scattered gear and power-coef handling.
Reworked Disable Game Shifting, N/R/H routing, pending gear sync (NextGear / Gear_2), and vehicle-switch re-sync.
Restored proper native auto behavior when manual-only options are disabled.
Blocked modded manual gear inputs while the truck is in native auto mode.
Added targeted debug logging to SMT_LOG.txt for shift requests, hook behavior, auto/manual transitions, and vehicle changes.
Improved config handling with runtime-safe option access and automatic saving when keybinds or options are changed.